### PR TITLE
Update Data Layer Browser Event Name

### DIFF
--- a/resources/views/header-script.blade.php
+++ b/resources/views/header-script.blade.php
@@ -21,7 +21,7 @@
                 window.ElevarDataLayer.push({!! $item->toJson() !!});
             @endforeach
 
-            window.addEventListener('push_to_data_layer', (event) => window.ElevarDataLayer.push(event.detail))
+            window.addEventListener('push-to-data-layer', (event) => window.ElevarDataLayer.push(event.detail))
         @else
             @unless(empty($dataLayer->toArray()))
                 window.dataLayer.push({!! $dataLayer->toJson() !!});
@@ -31,7 +31,7 @@
                 window.dataLayer.push({!! $item->toJson() !!});
             @endforeach
 
-            window.addEventListener('push_to_data_layer', (event) => window.dataLayer.push(event.detail))
+            window.addEventListener('push-to-data-layer', (event) => window.dataLayer.push(event.detail))
         @endif
     </script>
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/src/GtmServiceProvider.php
+++ b/src/GtmServiceProvider.php
@@ -34,7 +34,7 @@ class GtmServiceProvider extends PackageServiceProvider
     {
         $this->app['view']->creator([
             'gtm::header-script',
-            'gtm::body-script'
+            'gtm::body-script',
         ], ScriptViewCreator::class);
 
         resolve(Router::class)->pushMiddlewareToGroup(RouteServiceProvider::MIDDLEWARE_GROUP_FRONTEND, GoogleTagManagerMiddleware::class);

--- a/src/Http/Livewire/Traits/InteractsWithDataLayer.php
+++ b/src/Http/Livewire/Traits/InteractsWithDataLayer.php
@@ -12,6 +12,6 @@ trait InteractsWithDataLayer
             return;
         }
 
-        $this->dispatchBrowserEvent('push_to_data_layer', $data);
+        $this->dispatchBrowserEvent('push-to-data-layer', $data);
     }
 }


### PR DESCRIPTION
This PR is linked to https://linear.app/3zbrands/issue/DTCE-272/add-to-cart-event-tracking. 

This PR updates the browser event name from `push_to_data_layer`  to `push-to-data-layer`. This enables us to listen for the event using Alpine with `x-on:push-to-data-layer` 